### PR TITLE
Switched to a forked version of python-xbee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-.PHONY: venv clobber
+.PHONY: clobber install
 venv:
 	virtualenv -p python2.7 venv
+
+install: venv
+	venv/bin/pip install --upgrade pip
 	venv/bin/pip install -r requirements.txt
+	mkdir -p tmp
+	git clone https://github.com/thom-nic/python-xbee.git tmp/python-xbee
+	cd tmp/python-xbee; ../../venv/bin/python setup.py install
+	#this isn't optimal but later we'll test for existance of tmp/python-xbee before cloning with git (which will fail if python-xbee directory exists)
+	rm -rf tmp
 
 clobber:
 	rm -rf venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ pyserial==2.7
 python-dateutil==2.4.2
 pytz==2015.4
 six==1.9.0
-XBee==2.1.0


### PR DESCRIPTION
The new version of python-xbee is hosted on github. It allows timeouts
on serialport reads, so that we're not blocked forever while waiting for
a packet that was probably dropped.

CHANGES:
Makefile - make install - handles the pip operations now.
           It also does the git clone that we need in order to install
           python-xbee in our virtual environment

requirements.txt - removed python-xbee from requirements.txt